### PR TITLE
Enhance Linux FUSE installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Download the bundle or installer for your platform of choice, run it, and you're
 ### Linux
 
 If you are on Linux, you need FUSE to use the `.AppImage` files. If you don't already have it, install it with `sudo apt install libfuse2` (Debian based) or `sudo dnf install -y fuse-libs` (Fedora based).
-Next, toggle on "Executable as Program" in the file's properties.
+In GNOME, toggle on "Executable as Program" in the file's properties.
 
 ### SteamOS (Steam Deck)
 


### PR DESCRIPTION
Updated Linux installation instructions for FUSE to include Fedora-based commands and added a note about toggling executable properties.