### PR TITLE
fix: [Linux] Fix zombie process after YARG exit 

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -366,7 +366,7 @@ fn launch_profile(
                 "Failed to launch profile! Is the executable installed?\n{:?}", e
             ))?;
     } else if !use_obs_vkcapture {
-        Command::new(path)
+        let mut child = Command::new(path)
             .args(arguments)
             .env_remove("LD_LIBRARY_PATH")
             .spawn()
@@ -376,14 +376,16 @@ fn launch_profile(
                     e
                 )
             })?;
+        std::thread::spawn(move || { let _ = child.wait(); });
     } else {
         let path_str = path_to_string(path)?;
 
-        Command::new("obs-gamecapture")
+        let mut child = Command::new("obs-gamecapture")
             .args([path_str].iter().chain(&arguments))
             .env_remove("LD_LIBRARY_PATH")
             .spawn()
             .map_err(|e| format!("Failed to launch profile! Is the executable installed? Is obs-vkcapture installed and pathed?\n{:?}", e))?;
+        std::thread::spawn(move || { let _ = child.wait(); });
     }
 
     Ok(())


### PR DESCRIPTION
## Bug                                                                                                      
                                                                                                           
After exiting YARG through the in-game menu, the process enters a zombie (Z) state in the process table and remains 
there until the launcher itself is closed:
```bash
$ ps -efl | grep -i yarg
0 Z 38297   38159  6  80   0 -     0 -      17:11 ?        00:00:03 [YARG] <defunct>
```
Root cause: `launch_profile` calls `.spawn()` and immediately drops the returned `Child` handle. As noted in the Rust docs for [`std::process::Child`](https://doc.rust-lang.org/std/process/struct.Child.html) dropping a Child without calling `.wait()` can leave a zombie process since the parent never reaps the child. While mostly harmless, a process should never enter that state in the first place.

## Fix

The `Child` handle is captured and passed to a background thread that calls `.wait()`, reaping the process when it exits without blocking the launcher.

## Testing

Tested a local build on EndeavourOS (KDE Plasma, kernel 6.19.8-arch1-1). Verified via `ps -efl | grep -i yarg` that no zombie process remains after exiting YARG through the in-game menu.