### PR TITLE
Add quick launch and quick update buttons to side bar

### DIFF
--- a/src/assets/Icons/Play.svg
+++ b/src/assets/Icons/Play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play-icon lucide-play"><path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"/></svg>

--- a/src/assets/Icons/index.ts
+++ b/src/assets/Icons/index.ts
@@ -40,6 +40,7 @@ import SidebarUpdateIcon from "./SidebarUpdate.svg?react";
 import RedditIcon from "./Reddit.svg?react";
 import YoutubeIcon from "./Youtube.svg?react";
 import RefreshIcon from "./Refresh.svg?react";
+import PlayIcon from "./Play.svg?react";
 
 export {
     AddIcon,
@@ -77,4 +78,5 @@ export {
     RedditIcon,
     YoutubeIcon,
     RefreshIcon,
+    PlayIcon,
 };

--- a/src/components/Sidebar/Profiles/Selector.module.css
+++ b/src/components/Sidebar/Profiles/Selector.module.css
@@ -34,6 +34,7 @@
 }
 
 .tagInQueue {
+    margin-right: 8px;
     border: 2px solid #FCD548;
     color: #FCD548;
     background: rgba(252, 213, 72, 0.10);
@@ -44,10 +45,15 @@
 }
 
 .tagUpdate {
-    border: 2px solid #17E289;
-    color: #17E289;
-    background: rgba(23, 226, 137, 0.10);
-    animation: 1s linear 0s infinite running fade;
+    border: 6px solid #17E289;
+    color: #0C0F1E;
+    background: #17E289;
+}
+
+.tagLaunch {
+    border: 6px solid #45D8FE;
+    color: #0C0F1E;
+    background: #45D8FE;
 }
 
 [aria-current="page"] > .selector,

--- a/src/components/Sidebar/Profiles/Selector.tsx
+++ b/src/components/Sidebar/Profiles/Selector.tsx
@@ -2,6 +2,7 @@ import { ProfileFolderState, useProfileState } from "@app/hooks/useProfileState"
 import styles from "./Selector.module.css";
 import ProfileIcon from "@app/components/ProfileIcon";
 import { SidebarInQueueIcon, SidebarUpdateIcon } from "@app/assets/Icons";
+import {useEffect, useRef, useState} from "react";
 
 interface Props {
     name: string,
@@ -13,19 +14,46 @@ const Selector: React.FC<Props> = ({ name, uuid, iconUrl }: Props) => {
     const {
         loading,
         folderState,
-        currentTask
+        currentTask,
+        activeProfile,
+        launch,
+        downloadAndInstall,
     } = useProfileState(uuid);
+
+    const [launching, setLaunching] = useState<boolean>(false);
+    const launchTimeoutRef = useRef<NodeJS.Timeout>();
+    const lastPlayedChangeCount = useRef(0);
+    //count how often this triggers to skip the first 2 on initialization
+    useEffect(() => {
+        if (lastPlayedChangeCount.current > 1 && activeProfile.profile.type === "application") {
+            setLaunching(true);
+            launchTimeoutRef.current = setTimeout(() => {
+                setLaunching(false);
+            }, 10 * 1000);
+        }
+        lastPlayedChangeCount.current++;
+    }, [activeProfile.lastPlayed]);
 
     let tag = <></>;
     if (!loading) {
-        if (currentTask !== undefined) {
+        if (currentTask !== undefined || launching) {
             tag = <div className={[styles.tagInQueue, styles.tag].join(" ")}>
                 <SidebarInQueueIcon width={10} height={10} />
             </div>;
         } else if (folderState === ProfileFolderState.FirstDownload || folderState === ProfileFolderState.UpdateRequired) {
-            tag = <div className={[styles.tagUpdate, styles.tag].join(" ")}>
+            tag = <div className={[styles.tagUpdate, styles.tag].join(" ")} onClick={async (e) => {
+                e.preventDefault();
+                await downloadAndInstall();
+            }}>
                 <SidebarUpdateIcon width={10} height={10} />
             </div>;
+        } else if (folderState === ProfileFolderState.UpToDate && activeProfile.profile.type === "application") {
+            tag = <button className={[styles.tagUpdate, styles.tag].join(" ")} onClick={async (e) => {
+                e.preventDefault();
+                await launch();
+            }}>
+                <SidebarUpdateIcon width={10} height={10} />
+            </button>;
         }
     }
 

--- a/src/components/Sidebar/Profiles/Selector.tsx
+++ b/src/components/Sidebar/Profiles/Selector.tsx
@@ -1,7 +1,7 @@
 import { ProfileFolderState, useProfileState } from "@app/hooks/useProfileState";
 import styles from "./Selector.module.css";
 import ProfileIcon from "@app/components/ProfileIcon";
-import { SidebarInQueueIcon, SidebarUpdateIcon } from "@app/assets/Icons";
+import {PlayIcon, QueueIcon, SidebarInQueueIcon} from "@app/assets/Icons";
 import {useEffect, useRef, useState} from "react";
 
 interface Props {
@@ -38,21 +38,21 @@ const Selector: React.FC<Props> = ({ name, uuid, iconUrl }: Props) => {
     if (!loading) {
         if (currentTask !== undefined || launching) {
             tag = <div className={[styles.tagInQueue, styles.tag].join(" ")}>
-                <SidebarInQueueIcon width={10} height={10} />
+                <SidebarInQueueIcon width={14} height={14} />
             </div>;
         } else if (folderState === ProfileFolderState.FirstDownload || folderState === ProfileFolderState.UpdateRequired) {
             tag = <div className={[styles.tagUpdate, styles.tag].join(" ")} onClick={async (e) => {
                 e.preventDefault();
                 await downloadAndInstall();
             }}>
-                <SidebarUpdateIcon width={10} height={10} />
+                <QueueIcon width={18} height={18} />
             </div>;
         } else if (folderState === ProfileFolderState.UpToDate && activeProfile.profile.type === "application") {
-            tag = <button className={[styles.tagUpdate, styles.tag].join(" ")} onClick={async (e) => {
+            tag = <button className={[styles.tagLaunch, styles.tag].join(" ")} onClick={async (e) => {
                 e.preventDefault();
                 await launch();
             }}>
-                <SidebarUpdateIcon width={10} height={10} />
+                <PlayIcon width={18} height={18} />
             </button>;
         }
     }

--- a/src/routes/AppProfile/LaunchButton.tsx
+++ b/src/routes/AppProfile/LaunchButton.tsx
@@ -39,12 +39,17 @@ export function LaunchButton({ profileState }: Props) {
 
     const [launching, setLaunching] = useState<boolean>(false);
     const launchTimeoutRef = useRef<NodeJS.Timeout>();
-
-    // Make sure to reset the launching status when the profile changes
+    const lastPlayedChangeCount = useRef(0);
+    //count how often this triggers to skip the first 2 on initialization
     useEffect(() => {
-        setLaunching(false);
-        clearTimeout(launchTimeoutRef.current);
-    }, [activeProfile]);
+        if (lastPlayedChangeCount.current > 1 && activeProfile.profile.type === "application") {
+            setLaunching(true);
+            launchTimeoutRef.current = setTimeout(() => {
+                setLaunching(false);
+            }, 10 * 1000);
+        }
+        lastPlayedChangeCount.current++;
+    }, [activeProfile.lastPlayed]);
 
     const profile = activeProfile.profile;
 
@@ -143,13 +148,6 @@ export function LaunchButton({ profileState }: Props) {
     // Launch/up-to-date button
     if (folderState === ProfileFolderState.UpToDate) {
         return <Button color={ButtonColor.BLUE} rounded border onClick={async () => {
-            if (profile.type === "application") {
-                setLaunching(true);
-                launchTimeoutRef.current = setTimeout(() => {
-                    setLaunching(false);
-                }, 10 * 1000);
-            }
-
             await launch();
         }}>
             {profile.type === "application" &&


### PR DESCRIPTION
adds buttons to launch each installed application, and replaces the update available tag with a quick update button
<img width="292" height="326" alt="image" src="https://github.com/user-attachments/assets/67566c2d-362a-431b-b140-df52cceebf00" />
design based on Jaio's WIP launcher design

known issue/edge case: launching an application and then opening the application's page will not have it display "loading"
this is my first time working with react and i didn't think it's important enough to justify making a global state of which applications are launching.

the icon added is from the already used lucide icon set at https://lucide.dev